### PR TITLE
SS: Add CarbonGestures

### DIFF
--- a/res/layout/dialog_app_chooser_list.xml
+++ b/res/layout/dialog_app_chooser_list.xml
@@ -30,6 +30,9 @@
             android:layout_height="fill_parent"
             android:layout_toLeftOf="@+id/searchButton"
             android:ems="10"
+			android:imeOptions="actionSearch"
+            android:maxLines="1"
+            android:inputType="text"
             android:hint="@android:string/search_go" >
 
         </EditText>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -661,5 +661,37 @@
         <item>4</item>
         <item>5</item>
     </string-array>
+	
+	<string-array name="carbon_gestures_button_entries" translatable="false">
+        <item>@string/carbon_gesture_disabled</item>
+        <item>@string/carbon_gesture_back</item>
+        <item>@string/carbon_gesture_home</item>
+        <item>@string/carbon_gesture_recents</item>
+        <item>@string/carbon_gesture_power</item>
+        <item>@string/carbon_gesture_volume_down</item>
+        <item>@string/carbon_gesture_volume_up</item>
+        <item>@string/carbon_gesture_volume_mute</item>
+        <item>@string/carbon_gesture_screenshot</item>
+        <item>@string/carbon_gesture_media_play_pause</item>
+        <item>@string/carbon_gesture_media_skip</item>
+        <item>@string/carbon_gesture_media_previous</item>
+        <item>@string/carbon_gesture_customapp</item>
+    </string-array>
+
+    <string-array name="carbon_gestures_button_values" translatable="false">
+        <item>0</item>
+        <item>4</item>
+        <item>3</item>
+        <item>187</item>
+        <item>26</item>
+        <item>25</item>
+        <item>24</item>
+        <item>164</item>
+        <item>1000</item>
+        <item>85</item>
+        <item>87</item>
+        <item>88</item>
+        <item>1001</item>
+    </string-array>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -833,5 +833,28 @@
     <!-- System default animation -->
     <string name="system_default_animation_title">Android P animation style</string>
     <string name="system_default_animation_summary">Enable Android P \"Default\" animations</string>
+	
+	<!-- CarbonGestures -->
+    <string name="carbon_gesture_preference_title">CarbonGestures</string>
+    <string name="carbon_gestures_summary">Configure custom global gestures</string>
+    <string name="carbon_gestures_fingers_title">Fingers used for gesture</string>
+    <string name="carbon_gestures_right_title">Right gesture</string>
+    <string name="carbon_gestures_left_title">Left gesture</string>
+    <string name="carbon_gestures_up_title">Up gesture</string>
+    <string name="carbon_gestures_down_title">Down gesture</string>
+    <string name="carbon_gesture_disabled">Disabled</string>
+    <string name="carbon_gesture_back">Back</string>
+    <string name="carbon_gesture_home">Home</string>
+    <string name="carbon_gesture_recents">Recents</string>
+    <string name="carbon_gesture_power">Power</string>
+    <string name="carbon_gesture_volume_down">Volume down</string>
+    <string name="carbon_gesture_volume_up">Volume up</string>
+    <string name="carbon_gesture_volume_mute">Volume mute</string>
+    <string name="carbon_gesture_screenshot">Screenshot</string>
+    <string name="carbon_gesture_media_play_pause">Play/Pause media</string>
+    <string name="carbon_gesture_media_skip">Skip media</string>
+    <string name="carbon_gesture_media_previous">Previous media</string>
+    <string name="carbon_gesture_customapp">Launch application</string>
+    <string name="carbon_gesture_launch">Launch</string>
 
 </resources>

--- a/res/xml/carbongestures.xml
+++ b/res/xml/carbongestures.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The Android Open Source Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+ <PreferenceScreen
+     xmlns:android="http://schemas.android.com/apk/res/android"
+     android:title="@string/carbon_gesture_preference_title"
+     xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
+
+    <com.liquid.liquidlounge.preferences.CustomSeekBarPreference
+        android:key="carbon_gestures_fingers"
+        android:title="@string/carbon_gestures_fingers_title"
+        android:max="4"
+        settings:min="2" />
+
+    <ListPreference
+        android:key="carbon_gestures_right"
+        android:entries="@array/carbon_gestures_button_entries"
+        android:entryValues="@array/carbon_gestures_button_values"
+        android:summary="%s"
+        android:title="@string/carbon_gestures_right_title" />
+
+    <ListPreference
+        android:key="carbon_gestures_left"
+        android:entries="@array/carbon_gestures_button_entries"
+        android:entryValues="@array/carbon_gestures_button_values"
+        android:summary="%s"
+        android:title="@string/carbon_gestures_left_title" />
+
+    <ListPreference
+        android:key="carbon_gestures_up"
+        android:entries="@array/carbon_gestures_button_entries"
+        android:entryValues="@array/carbon_gestures_button_values"
+        android:summary="%s"
+        android:title="@string/carbon_gestures_up_title" />
+
+    <ListPreference
+        android:key="carbon_gestures_down"
+        android:entries="@array/carbon_gestures_button_entries"
+        android:entryValues="@array/carbon_gestures_button_values"
+        android:summary="%s"
+        android:title="@string/carbon_gestures_down_title" />
+</PreferenceScreen>

--- a/res/xml/gestures_settings.xml
+++ b/res/xml/gestures_settings.xml
@@ -54,5 +54,10 @@
         android:title="@string/torch_power_button_gesture_title"
         android:entries="@array/torch_power_button_gesture_entries"
         android:entryValues="@array/torch_power_button_gesture_values" />
+		
+	<Preference
+        android:title="@string/carbon_gesture_preference_title"
+        android:key="carbongestures"
+        android:fragment="com.liquid.liquidlounge.fragments.CarbonGesturesSettings" />	
 
 </PreferenceScreen>

--- a/src/com/liquid/liquidlounge/fragments/CarbonGesturesSettings.java
+++ b/src/com/liquid/liquidlounge/fragments/CarbonGesturesSettings.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2018 CarbonROM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liquid.liquidlounge.fragments;
+
+import android.content.Context;
+import android.content.ContentResolver;
+import android.content.res.Resources;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.Preference.OnPreferenceChangeListener;
+import android.support.v7.preference.PreferenceCategory;
+import android.support.v7.preference.PreferenceCategory;
+import android.support.v7.preference.PreferenceScreen;
+import android.support.v7.preference.ListPreference;
+import android.support.v14.preference.SwitchPreference;
+import android.provider.Settings;
+
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.settings.Utils;
+
+import com.liquid.liquidlounge.preferences.CustomSeekBarPreference;
+import com.liquid.liquidlounge.fragments.HAFRAppChooserAdapter.AppItem;
+import com.liquid.liquidlounge.fragments.HAFRAppChooserDialog;
+
+public class CarbonGesturesSettings extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener {
+    private static final String TAG = "CarbonGestures";
+    private CustomSeekBarPreference mCarbonGestureFingers;
+    private ListPreference mCarbonGestureRight;
+    private ListPreference mCarbonGestureLeft;
+    private ListPreference mCarbonGestureUp;
+    private ListPreference mCarbonGestureDown;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        addPreferencesFromResource(R.xml.carbongestures);
+
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        mCarbonGestureFingers = (CustomSeekBarPreference) findPreference("carbon_gestures_fingers");
+        mCarbonGestureFingers.setOnPreferenceChangeListener(this);
+        int carbonGestureFingers = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_FINGERS,
+                2, UserHandle.USER_CURRENT);
+        mCarbonGestureFingers.setValue(carbonGestureFingers);
+
+        mCarbonGestureRight = (ListPreference) findPreference("carbon_gestures_right");
+        mCarbonGestureRight.setOnPreferenceChangeListener(this);
+        int carbonGestureRight = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_RIGHT,
+                0, UserHandle.USER_CURRENT);
+        mCarbonGestureRight.setValue(String.valueOf(carbonGestureRight));
+        if (carbonGestureRight == 1001) {
+            setApplicationNamePreferenceSummary(Settings.System.getStringForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_RIGHT,
+                UserHandle.USER_CURRENT), mCarbonGestureRight);
+        } else {
+            mCarbonGestureRight.setSummary(mCarbonGestureRight.getEntry());
+        }
+
+        mCarbonGestureLeft = (ListPreference) findPreference("carbon_gestures_left");
+        mCarbonGestureLeft.setOnPreferenceChangeListener(this);
+        int carbonGestureLeft = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_LEFT,
+                0, UserHandle.USER_CURRENT);
+        mCarbonGestureLeft.setValue(String.valueOf(carbonGestureLeft));
+        if (carbonGestureLeft == 1001) {
+            setApplicationNamePreferenceSummary(Settings.System.getStringForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_LEFT,
+                UserHandle.USER_CURRENT), mCarbonGestureLeft);
+        } else {
+            mCarbonGestureLeft.setSummary(mCarbonGestureLeft.getEntry());
+        }
+
+        mCarbonGestureUp = (ListPreference) findPreference("carbon_gestures_up");
+        mCarbonGestureUp.setOnPreferenceChangeListener(this);
+        int carbonGestureUp = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_UP,
+                0, UserHandle.USER_CURRENT);
+        mCarbonGestureUp.setValue(String.valueOf(carbonGestureUp));
+        if (carbonGestureUp == 1001) {
+            setApplicationNamePreferenceSummary(Settings.System.getStringForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_UP,
+                UserHandle.USER_CURRENT), mCarbonGestureUp);
+        } else {
+            mCarbonGestureUp.setSummary(mCarbonGestureUp.getEntry());
+        }
+
+        mCarbonGestureDown = (ListPreference) findPreference("carbon_gestures_down");
+        mCarbonGestureDown.setOnPreferenceChangeListener(this);
+        int carbonGestureDown = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_DOWN,
+                0, UserHandle.USER_CURRENT);
+        mCarbonGestureDown.setValue(String.valueOf(carbonGestureDown));
+        if (carbonGestureDown == 1001) {
+            setApplicationNamePreferenceSummary(Settings.System.getStringForUser(getContentResolver(),
+                Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_DOWN,
+                UserHandle.USER_CURRENT), mCarbonGestureDown);
+        } else {
+            mCarbonGestureDown.setSummary(mCarbonGestureDown.getEntry());
+        }
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.LIQUID;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+    }
+
+    private void launchAppChooseDialog(String setting, ListPreference pref) {
+        HAFRAppChooserDialog dDialog = new HAFRAppChooserDialog(getActivity()) {
+            @Override
+            public void onListViewItemClick(AppItem info, int id) {
+                Settings.System.putStringForUser(getContentResolver(),
+                    setting, info.packageName, UserHandle.USER_CURRENT);
+                setApplicationNamePreferenceSummary(info.packageName, pref);
+            }
+        };
+        dDialog.setCancelable(false);
+        dDialog.setLauncherFilter(true);
+        dDialog.show(1);
+    }
+
+    private void setApplicationNamePreferenceSummary(String pkg, ListPreference pref) {
+        PackageManager packageManager = getActivity().getApplicationContext().getPackageManager();
+        String packageInfo = "";
+        try {
+            packageInfo = packageManager.getApplicationLabel(packageManager.getApplicationInfo(pkg, PackageManager.GET_META_DATA)).toString();
+            } catch (PackageManager.NameNotFoundException e) {
+                e.printStackTrace();
+            }
+        pref.setSummary(getActivity().getString(R.string.carbon_gesture_launch) + " " + packageInfo);
+    }
+
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        ContentResolver resolver = getActivity().getContentResolver();
+        if (preference.equals(mCarbonGestureFingers)) {
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.CARBON_CUSTOM_GESTURE_FINGERS, (Integer) objValue, UserHandle.USER_CURRENT);
+            return true;
+        }
+
+        if (preference.equals(mCarbonGestureRight)) {
+            int carbonGestureRight = Integer.parseInt(((String) objValue).toString());
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.CARBON_CUSTOM_GESTURE_RIGHT, carbonGestureRight, UserHandle.USER_CURRENT);
+            int index = mCarbonGestureRight.findIndexOfValue((String) objValue);
+            if (carbonGestureRight == 1001) {
+                launchAppChooseDialog(Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_RIGHT, mCarbonGestureRight);
+            } else {
+                mCarbonGestureRight.setSummary(
+                        mCarbonGestureRight.getEntries()[index]);
+            }
+            return true;
+        }
+
+        if (preference.equals(mCarbonGestureLeft)) {
+            int carbonGestureLeft = Integer.parseInt(((String) objValue).toString());
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.CARBON_CUSTOM_GESTURE_LEFT, carbonGestureLeft, UserHandle.USER_CURRENT);
+            int index = mCarbonGestureLeft.findIndexOfValue((String) objValue);
+            if (carbonGestureLeft == 1001) {
+                launchAppChooseDialog(Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_LEFT, mCarbonGestureLeft);
+            } else {
+                mCarbonGestureLeft.setSummary(
+                        mCarbonGestureLeft.getEntries()[index]);
+            }
+            return true;
+        }
+
+        if (preference.equals(mCarbonGestureUp)) {
+            int carbonGestureUp = Integer.parseInt(((String) objValue).toString());
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.CARBON_CUSTOM_GESTURE_UP, carbonGestureUp, UserHandle.USER_CURRENT);
+            int index = mCarbonGestureUp.findIndexOfValue((String) objValue);
+            if (carbonGestureUp == 1001) {
+                launchAppChooseDialog(Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_UP, mCarbonGestureUp);
+            } else {
+                mCarbonGestureUp.setSummary(
+                        mCarbonGestureUp.getEntries()[index]);
+            }
+            return true;
+        }
+
+        if (preference.equals(mCarbonGestureDown)) {
+            int carbonGestureDown = Integer.parseInt(((String) objValue).toString());
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.CARBON_CUSTOM_GESTURE_DOWN, carbonGestureDown, UserHandle.USER_CURRENT);
+            int index = mCarbonGestureDown.findIndexOfValue((String) objValue);
+            if (carbonGestureDown == 1001) {
+                launchAppChooseDialog(Settings.System.CARBON_CUSTOM_GESTURE_PACKAGE_DOWN, mCarbonGestureDown);
+            } else {
+                mCarbonGestureDown.setSummary(
+                        mCarbonGestureDown.getEntries()[index]);
+            }
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/com/liquid/liquidlounge/fragments/HAFRAppChooserAdapter.java
+++ b/src/com/liquid/liquidlounge/fragments/HAFRAppChooserAdapter.java
@@ -1,0 +1,191 @@
+package com.liquid.liquidlounge.fragments;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.android.settings.R;
+
+public abstract class HAFRAppChooserAdapter extends BaseAdapter implements Filterable {
+
+    final Context mContext;
+    final Handler mHandler;
+    final PackageManager mPackageManager;
+    final LayoutInflater mLayoutInflater;
+
+    protected List<PackageInfo> mInstalledAppInfo;
+    protected List<AppItem> mInstalledApps = new LinkedList<AppItem>();
+    protected List<PackageInfo> mTemporarylist;
+
+    boolean isUpdating;
+    boolean hasLauncherFilter = false;
+
+    public HAFRAppChooserAdapter(Context context) {
+        mContext = context;
+        mHandler = new Handler();
+        mPackageManager = mContext.getPackageManager();
+        mLayoutInflater = (LayoutInflater) mContext
+                .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        mInstalledAppInfo = mPackageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS);
+        mTemporarylist = mInstalledAppInfo;
+    }
+
+    public synchronized void update() {
+        onStartUpdate();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                isUpdating = true;
+                final List<AppItem> temp = new LinkedList<AppItem>();
+                for (PackageInfo info : mTemporarylist) {
+                    final AppItem item = new AppItem();
+                    item.title = info.applicationInfo.loadLabel(mPackageManager);
+                    item.icon = info.applicationInfo.loadIcon(mPackageManager);
+                    item.packageName = info.packageName;
+                    final int index = Collections.binarySearch(temp, item);
+                    final boolean isLauncherApp =
+                            mPackageManager.getLaunchIntentForPackage(info.packageName) != null;
+                    if (!hasLauncherFilter || isLauncherApp) {
+                        if (index < 0) {
+                            temp.add((-index - 1), item);
+                        } else {
+                            temp.add((index + 1), item);
+                        }
+                    }
+                }
+                mHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        mInstalledApps = temp;
+                        notifyDataSetChanged();
+                        isUpdating = false;
+                        onFinishUpdate();
+                    }
+                });
+            }
+        }).start();
+    }
+
+    public abstract void onStartUpdate();
+
+    public abstract void onFinishUpdate();
+
+    @Override
+    public int getCount() {
+        return mInstalledApps.size();
+    }
+
+    @Override
+    public AppItem getItem(int position) {
+        if (position >= mInstalledApps.size()) {
+            return mInstalledApps.get(mInstalledApps.size());
+        } else if (position < 0) {
+            return mInstalledApps.get(0);
+        }
+
+        return mInstalledApps.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        if (position < 0 || position >= mInstalledApps.size()) {
+            return -1;
+        }
+
+        return getItem(position).hashCode();
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ViewHolder holder;
+        if (convertView != null) {
+            holder = (ViewHolder) convertView.getTag();
+        } else {
+            convertView = mLayoutInflater.inflate(R.layout.view_app_list, parent, false);
+            holder = new ViewHolder();
+            holder.name = (TextView) convertView.findViewById(android.R.id.title);
+            holder.icon = (ImageView) convertView.findViewById(android.R.id.icon);
+            holder.pkg = (TextView) convertView.findViewById(android.R.id.message);
+            convertView.setTag(holder);
+        }
+        AppItem appInfo = getItem(position);
+
+        holder.name.setText(appInfo.title);
+        holder.pkg.setText(appInfo.packageName);
+        holder.icon.setImageDrawable(appInfo.icon);
+        return convertView;
+    }
+
+    @Override
+    public Filter getFilter() {
+        return new Filter() {
+            @Override
+            protected void publishResults(CharSequence constraint, FilterResults results) {
+            }
+
+            @Override
+            protected FilterResults performFiltering(CharSequence constraint) {
+                if (TextUtils.isEmpty(constraint)) {
+                    // No filter implemented we return all the list
+                    mTemporarylist = mInstalledAppInfo;
+                    return new FilterResults();
+                }
+
+                ArrayList<PackageInfo> FilteredList = new ArrayList<PackageInfo>();
+                for (PackageInfo data : mInstalledAppInfo) {
+                    final String filterText = constraint.toString().toLowerCase(Locale.ENGLISH);
+                    try {
+                        if (data.applicationInfo.loadLabel(mPackageManager).toString()
+                                .toLowerCase(Locale.ENGLISH).contains(filterText)) {
+                            FilteredList.add(data);
+                        } else if (data.packageName.contains(filterText)) {
+                            FilteredList.add(data);
+                        }
+                    } catch (Exception e) {
+                    }
+                }
+                mTemporarylist = FilteredList;
+                return new FilterResults();
+            }
+        };
+    }
+
+    public class AppItem implements Comparable<AppItem> {
+        public CharSequence title;
+        public String packageName;
+        public Drawable icon;
+
+        @Override
+        public int compareTo(AppItem another) {
+            return this.title.toString().compareTo(another.title.toString());
+        }
+    }
+
+    static class ViewHolder {
+        TextView name;
+        ImageView icon;
+        TextView pkg;
+    }
+
+    protected void setLauncherFilter(boolean enabled) {
+        hasLauncherFilter = enabled;
+    }
+}

--- a/src/com/liquid/liquidlounge/fragments/HAFRAppChooserDialog.java
+++ b/src/com/liquid/liquidlounge/fragments/HAFRAppChooserDialog.java
@@ -1,0 +1,102 @@
+package com.liquid.liquidlounge.fragments;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.view.inputmethod.EditorInfo;
+import android.view.View;
+import android.view.Window;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.EditText;
+import android.widget.Filter;
+import android.widget.ImageButton;
+import android.view.KeyEvent;
+import android.widget.ListView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.android.settings.R;
+
+public abstract class HAFRAppChooserDialog extends Dialog {
+
+    final HAFRAppChooserAdapter dAdapter;
+    final ProgressBar dProgressBar;
+    final ListView dListView;
+    final EditText dSearch;
+    final ImageButton dButton;
+
+    private int mId;
+
+    public HAFRAppChooserDialog(Context context) {
+        super(context);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        setContentView(R.layout.dialog_app_chooser_list);
+
+        dListView = (ListView) findViewById(R.id.listView1);
+        dSearch = (EditText) findViewById(R.id.searchText);
+        dButton = (ImageButton) findViewById(R.id.searchButton);
+        dProgressBar = (ProgressBar) findViewById(R.id.progressBar1);
+
+        dAdapter = new HAFRAppChooserAdapter(context) {
+            @Override
+            public void onStartUpdate() {
+                dProgressBar.setVisibility(View.VISIBLE);
+            }
+
+            @Override
+            public void onFinishUpdate() {
+                dProgressBar.setVisibility(View.GONE);
+            }
+        };
+
+        dListView.setAdapter(dAdapter);
+        dListView.setOnItemClickListener(new OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> av, View v, int pos, long id) {
+                HAFRAppChooserAdapter.AppItem info = (HAFRAppChooserAdapter.AppItem) av
+                        .getItemAtPosition(pos);
+                onListViewItemClick(info, mId);
+                dismiss();
+            }
+        });
+
+        dButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dAdapter.getFilter().filter(dSearch.getText().toString(), new Filter.FilterListener() {
+                    public void onFilterComplete(int count) {
+                        dAdapter.update();
+                    }
+                });
+            }
+        });
+
+        dSearch.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                    dAdapter.getFilter().filter(dSearch.getText().toString(), new Filter.FilterListener() {
+                        public void onFilterComplete(int count) {
+                            dAdapter.update();
+                        }
+                    });
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        dAdapter.update();
+    }
+
+    public void show(int id) {
+        mId = id;
+        show();
+    }
+
+    public void setLauncherFilter(boolean enabled) {
+        dAdapter.setLauncherFilter(enabled);
+    }
+
+    public abstract void onListViewItemClick(HAFRAppChooserAdapter.AppItem info, int id);
+}


### PR DESCRIPTION
* The origininal purpose of this was to use it for Navigation on devices without hardware buttons that dont want to use a Navbar for whatever reasons.
* Now allows emulating all kind of KeyEvents passed to it by CF, as well as being able to capture screenshots and lauch Apps.
* The carbon_gestures_button_values array is fully extendable with all Android KeyEvents, only values >999 are custom handled in FWB.
* Thanks to Alex and Ezio for their help

Dabug edits-
squashed commit d791b8f315f757f9c21b37248ce4033b8c3d0faf and added HAFRAppChooserDialog.java and HAFRAppChooserAdapter.java

Signed-off-by: Dabug123 <clarkbrunswick55@gmail.com>