### PR TITLE
Cleanup brightness slider toggle [2/2]

### DIFF
--- a/res/values/liquid_strings.xml
+++ b/res/values/liquid_strings.xml
@@ -304,8 +304,6 @@
     <!-- Quick Settings brightness slider -->
     <string name="qs_brightness_position_bottom_title">Brightness slider on bottom</string>
     <string name="qs_brightness_position_bottom_summary">Show a brightness slider on bottom quick settings</string>
-    <string name="brightness_icon_title">Auto Brightness Icon</string>
-    <string name="brightness_icon_summary">Show a brightness icon to the left of the brightness slider to adjust auto-brightness</string>
 
     <!-- Torch Power gestures -->
     <string name="torch_long_press_power_gesture_title">Screen off power button torch</string>

--- a/res/xml/quick_settings.xml
+++ b/res/xml/quick_settings.xml
@@ -42,23 +42,23 @@
         android:persistent="false" />
 
     <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference
-        android:key="qs_show_brightness_slider"
+        android:key="qs_show_brightness"
         android:title="@string/brightness_slider_title"
         android:summary="@string/brightness_slider_summary"
         android:defaultValue="true" />
 
-    <com.liquid.liquidlounge.preferences.SystemSettingSwitchPreference
+    <!--<com.liquid.liquidlounge.preferences.SystemSettingSwitchPreference
         android:key="qs_show_brightness_icon"
         android:title="@string/brightness_icon_title"
         android:summary="@string/brightness_icon_summary"
-        android:dependency="qs_show_brightness_slider"
-        android:defaultValue="false" />
+        android:dependency="qs_show_brightness"
+        android:defaultValue="false" /> -->
 
     <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference
         android:key="qs_brightness_position_bottom"
         android:title="@string/qs_brightness_position_bottom_title"
         android:summary="@string/qs_brightness_position_bottom_summary"
-        android:dependency="qs_show_brightness_slider"
+        android:dependency="qs_show_brightness"
         android:defaultValue="false" />
 
     <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference


### PR DESCRIPTION
Revert "Add option to disable auto brightness icon in brightness slider [2/2]"

Note : This fixes qs anmation glitch on pulldown. As tradeoff removes auto brightness toggle from qs. Will look into that later.

This reverts commit c3bad9d15d80c1ed9ad6fdfc333d18cb75866ea9.

Change-Id: Ia44c397de48f128d694dc390666f5a48fd5610c4

Cleanup brightness slider toggle [2/2]

Change-Id: I1ddc93ad788b4d1d7d9296eafa9bb4ac083f753e
Signed-off-by: sayan7848 <sayan7848@gmail.com>