### PR TITLE
Make recents icon pack independent of recents style

### DIFF
--- a/res/xml/recents_settings.xml
+++ b/res/xml/recents_settings.xml
@@ -26,6 +26,11 @@
         android:entries="@array/recents_type_title_entries"
         android:defaultValue="0"
         android:entryValues="@array/recents_type_title_values"/>
+	
+    <Preference
+        android:key="recents_icon_pack"
+        android:title="@string/recents_icon_pack_title"
+        android:summary="@string/recents_icon_pack_summary" />
 
     <PreferenceCategory
         android:key="stock_recents"
@@ -57,10 +62,6 @@
             android:summary="@string/recent_styles_summary"
             android:fragment="com.liquid.liquidlounge.fragments.RecentsStyles" />
 
-		<Preference
-        	android:key="recents_icon_pack"
-        	android:title="@string/recents_icon_pack_title"
-        	android:summary="@string/recents_icon_pack_summary" />
 
     </PreferenceCategory>
 

--- a/src/com/liquid/liquidlounge/fragments/RecentsSettings.java
+++ b/src/com/liquid/liquidlounge/fragments/RecentsSettings.java
@@ -185,7 +185,7 @@ public class RecentsSettings extends SettingsPreferenceFragment
                 Settings.Secure.putInt(getActivity().getContentResolver(),
                     Settings.Secure.SWIPE_UP_TO_SWITCH_APPS_ENABLED, 0);
             }
-            LiquidUtils.restartSystemUi(getContext());
+            LiquidUtils.showSystemUiRestartDialog(getContext());
             return true;
         } else if (preference == mImmersiveRecents) {
             int mode = Integer.valueOf((String) objValue); 
@@ -268,6 +268,7 @@ public class RecentsSettings extends SettingsPreferenceFragment
                 Settings.System.putString(getContext().getContentResolver(),
                         Settings.System.RECENTS_ICON_PACK, selectedPackage);
                 mDialog.dismiss();
+                LiquidUtils.showSystemUiRestartDialog(getContext());
             }
         });
 


### PR DESCRIPTION
Also add option to restart system ui after changing recents icon pack
While we are at it, bring back the previous graceful systemui restart dialog on changing recents style

Signed-off-by: sayan7848 <sayan7848@gmail.com>