### PR TITLE
Brightness QS: more user options

### DIFF
--- a/res/values/liquid_devices.xml
+++ b/res/values/liquid_devices.xml
@@ -93,4 +93,7 @@
     <string name="device_xiaomi_whyred">Redmi Note 5 Pro</string>
     <string name="device_xiaomi_whyred_summary">Whyred\nMaintainer - Ayan Choudhury (Nuuuuuuuu)</string>
 
+    <string name="device_xiaomi_mido">Redmi Note 4x</string>
+    <string name="device_xiaomi_mido_summary">Mido\nMaintainer - Sayan Sarkar (sayan7848)</string>
+
 </resources>

--- a/res/values/liquid_strings.xml
+++ b/res/values/liquid_strings.xml
@@ -1304,5 +1304,13 @@
     <string name="donate_liquid_summary">Donate to support development and our server</string>
     <string name="donate_dev_title" translatable="false">Ryan Birnesser (liquid0624)</string>
     <string name="donate_dev_summary">Lead Developer and Founder - Donate for a beer or a coffee!</string>
-	
+
+    <!-- QS Auto brightness toggle -->
+    <string name="brightness_icon_title">Auto brightness icon</string>
+    <string name="brightness_icon_summary">Show an icon to toggle auto-brightness</string>
+    <string name="qs_auto_brightness_right_title">Auto brightness icon on right</string>
+    <string name="qs_auto_brightness_right_summary">Show the icon on right of the brightness slider</string>
+    <string name="qs_show_brightness_buttons_title">Brightness control buttons</string>
+    <string name="qs_show_brightness_buttons_summary">Show buttons beside the brightness slider to adjust brightness</string>
+
 </resources>

--- a/res/xml/device_maintainers.xml
+++ b/res/xml/device_maintainers.xml
@@ -178,5 +178,12 @@
             android:summary="@string/device_xiaomi_whyred_summary"
             android:selectable="false" />
          
+         <Preference
+            android:id="@+id/device_xiaomi_mido"
+            android:icon="@drawable/phone_tint"
+            android:title="@string/device_xiaomi_mido"
+            android:summary="@string/device_xiaomi_mido_summary"
+            android:selectable="false" />
+
     </PreferenceCategory>
 </PreferenceScreen>

--- a/res/xml/quick_settings.xml
+++ b/res/xml/quick_settings.xml
@@ -62,6 +62,27 @@
         android:defaultValue="false" />
 
     <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference
+        android:key="qs_show_auto_brightness"
+        android:title="@string/brightness_icon_title"
+        android:summary="@string/brightness_icon_summary"
+        android:dependency="qs_show_brightness"
+        android:defaultValue="false"/>
+
+    <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference
+        android:key="qs_auto_brightness_right"
+        android:title="@string/qs_auto_brightness_right_title"
+        android:summary="@string/qs_auto_brightness_right_summary"
+        android:dependency="qs_show_auto_brightness"
+        android:defaultValue="true"/>
+
+    <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference
+        android:key="qs_show_brightness_buttons"
+        android:title="@string/qs_show_brightness_buttons_title"
+        android:summary="@string/qs_show_brightness_buttons_summary"
+        android:dependency="qs_show_brightness"
+        android:defaultValue="true"/>
+
+    <com.liquid.liquidlounge.preferences.SecureSettingSwitchPreference
         android:key="qs_show_drag_handle"
         android:title="@string/tuner_show_drag_handle_title"
         android:summary="@string/tuner_show_drag_handle_summary"


### PR DESCRIPTION
@SKULSHADY: Adapt for Havoc Settings
@sayan7848: Adapt for LiquidLounge

Signed-off-by: sayan7848 <sayan7848@gmail.com>

This introduces the following change : 
[2/2] Add auto-brightness toggle in quick-settings (without introducing the janky qs animation)